### PR TITLE
cinnamon-desktop requires accountsservice

### DIFF
--- a/BUILD_ORDER
+++ b/BUILD_ORDER
@@ -12,6 +12,7 @@ cjs
 cracklib
 pam
 python-pam
+accountsservice
 cinnamon-desktop
 json-glib
 pangox-compat
@@ -40,7 +41,6 @@ pexpect
 BeautifulSoup
 lxml
 metacity
-accountsservice
 alacarte
 polib
 cinnamon-translations

--- a/build-cinnamon.sh
+++ b/build-cinnamon.sh
@@ -56,6 +56,7 @@ for dir in \
   cracklib \
   pam \
   python-pam \
+  accountsservice \
   cinnamon-desktop \
   json-glib \
   pangox-compat \
@@ -84,7 +85,6 @@ for dir in \
   BeautifulSoup \
   lxml \
   metacity \
-  accountsservice \
   alacarte \
   polib \
   cinnamon-translations \


### PR DESCRIPTION
Hey again Willy,

I ran into an issue where cinnamon-desktop is complaining about missing accountsservice. Just updating the build order fixes it. This is on both master and 14.2 branches. And of course I'm using a fresh/clean full install of Slackware.

Thanks,
Ed