### PR TITLE
cinnamon: Disable gtk-doc

### DIFF
--- a/cinnamon/cinnamon.SlackBuild
+++ b/cinnamon/cinnamon.SlackBuild
@@ -111,6 +111,7 @@ CXXFLAGS="$SLKCFLAGS" \
   --docdir=/usr/doc/$PRGNAM-$VERSION \
   --enable-introspection=yes \
   --enable-compile-warnings=no \
+  --enable-gtk-doc=no \
   --disable-schemas-compile \
   --build=$ARCH-slackware-linux
 


### PR DESCRIPTION
I ran into another issue on a fresh install of current (03/July/2017). Disabling gtk-doc fixes it. I have only tested this on -current so far.