### PR TITLE
graphviz: Update download link

### DIFF
--- a/graphviz/graphviz.SlackBuild
+++ b/graphviz/graphviz.SlackBuild
@@ -39,7 +39,7 @@ if [ -z "$ARCH" ]; then
   esac
 fi
 
-wget -c http://graphviz.org/pub/graphviz/stable/SOURCES/$PRGNAM-$VERSION.tar.gz
+wget -c https://graphviz.gitlab.io/pub/graphviz/stable/SOURCES/$PRGNAM.tar.gz
 
 CWD=$(pwd)
 TMP=${TMP:-/tmp/csb}


### PR DESCRIPTION
They changed the download links for graphviz, and I don't know if this is the way you want to do it since the version number is no longer in the downloaded file, but it is in the extracted directory, and the md5sum is the same. The extract command will need to bee fixed as well.