### PR TITLE
python 3.8 platform.linux_distribution

### DIFF
--- a/cinnamon/cinnamon.SlackBuild
+++ b/cinnamon/cinnamon.SlackBuild
@@ -70,6 +70,9 @@ find -L . \
   -o -perm 511 \) -exec chmod 755 {} \; -o \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
+  
+# Patch to fix platform.linux_distribution with python 3.8
+patch -p1 < $CWD/python_3.8_platform.patch
 
 # Use cinnamon theme by default
 patch -p1 < $CWD/default-theme.patch

--- a/cinnamon/python_3.8_platform.patch
+++ b/cinnamon/python_3.8_platform.patch
@@ -1,0 +1,20 @@
+--- a/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
++++ b/files/usr/share/cinnamon/cinnamon-settings/modules/cs_info.py
+@@ -1,6 +1,7 @@
+ #!/usr/bin/python3
+ 
+ import platform
++import distro
+ import subprocess
+ import shlex
+ import os
+@@ -105,7 +106,7 @@
+         title = ' '.join(contents[:2]) or "Manjaro Linux"
+         infos.append((_("Operating System"), title))
+     else:
+-        s = '%s (%s)' % (' '.join(platform.linux_distribution()), arch)
++        s = '%s (%s)' % (' '.join(distro.linux_distribution()), arch)
+         # Normalize spacing in distribution name
+         s = re.sub('\s{2,}', ' ', s)
+         infos.append((_("Operating System"), s))
+


### PR DESCRIPTION
Here is a fix for python 3.8 where platform.linux_distribution is no more.

It can be confirmed by trying Menu -> Preferences -> System Info