### PR TITLE
Fix build with GCC 15

### DIFF
--- a/cogl/cogl.SlackBuild
+++ b/cogl/cogl.SlackBuild
@@ -74,8 +74,8 @@ find -L . \
  \( -perm 666 -o -perm 664 -o -perm 640 -o -perm 600 -o -perm 444 \
   -o -perm 440 -o -perm 400 \) -exec chmod 644 {} \;
 
-CFLAGS="$SLKCFLAGS" \
-CXXFLAGS="$SLKCFLAGS" \
+CFLAGS="$SLKCFLAGS -std=gnu17" \
+CXXFLAGS="$SLKCFLAGS -std=gnu17" \
 ./configure \
   --prefix=/usr \
   --libdir=/usr/lib${LIBDIRSUFFIX} \


### PR DESCRIPTION
Fix build with GCC 15
    
GCC 15 defaults to C23, but the latest release is from 2020, and this is no longer under development.